### PR TITLE
Fix wrong boolean values parsing

### DIFF
--- a/parsezeeklogs/__init__.py
+++ b/parsezeeklogs/__init__.py
@@ -149,7 +149,7 @@ class ParseZeekLogs(object):
                         else:
                             keys_to_delete.append(k)
                     elif data_types.get(k) == "bool":
-                        data[k] = bool(v)
+                        data[k] = str(v).lower() == 't'
                     else:
                         data[k] = v
 


### PR DESCRIPTION
`bool` type fields were parsing at line 152 using
```
data[k] = bool(v)
```
This will always return `True` if the content of the `v` variable is not the empty string.

I changed that line to
```
data[k] = str(v).lower() == 't'
```