### PR TITLE
Fix call to strip() removing trailing tabs needed for column alignment

### DIFF
--- a/parsezeeklogs/__init__.py
+++ b/parsezeeklogs/__init__.py
@@ -28,7 +28,7 @@ class ParseZeekLogs(object):
         meta = loads(dumps(meta).replace("'", '"'))
 
         # Read the header option lines
-        l = self.fd.readline().strip()
+        l = self.fd.readline().strip("\n")
         while l.strip().startswith("#"):
             # Parse the options out
             if l.startswith("#separator"):
@@ -41,7 +41,7 @@ class ParseZeekLogs(object):
                 self.options[key] = value
 
             # Read the next line
-            l = self.fd.readline().strip()
+            l = self.fd.readline().strip("\n")
 
         self.firstLine = l
 

--- a/parsezeeklogs/__init__.py
+++ b/parsezeeklogs/__init__.py
@@ -75,7 +75,7 @@ class ParseZeekLogs(object):
             retVal = self.firstLine
             self.firstRun = False
         else:
-            retVal = self.fd.readline().strip()
+            retVal = self.fd.readline().strip("\n")
 
         # If an empty string is returned, readline is done reading
         if retVal == "" or retVal is None:


### PR DESCRIPTION
When the zeek log doesn't have any value in the final column, the call to `readline.strip()` removes the trailing tabs. This causes the number of values in the record line to be fewer than the number of values in the header line, and it skips those records. This results in all records without that final column value being `None`, even though they are valid lines. 